### PR TITLE
Add important to purple and delayed next buttons.

### DIFF
--- a/frontend/src/components/DelayedNextButton.tsx
+++ b/frontend/src/components/DelayedNextButton.tsx
@@ -1,19 +1,24 @@
 import { Button } from "antd";
-import React, {MouseEvent, ReactElement, useState, useEffect } from "react";
+import React, {
+  MouseEvent,
+  ReactElement,
+  useState,
+  useEffect,
+} from "react";
 import styled from "styled-components";
 import { INK, INK_HOVER } from "../constants/colors";
 
 interface NextButtonProps {
-  top?: number,
-  text?: string | '',
-  onClick?:((event: MouseEvent<HTMLInputElement>) => void),
-  icon?: ReactElement,
-  className: string,
-  delay: number
+  top?: number;
+  text?: string | "";
+  onClick?: (event: MouseEvent<HTMLInputElement>) => void;
+  icon?: ReactElement;
+  className: string;
+  delay: number;
 }
 
 const ButtonContainer = styled(Button)`
-  background: ${INK};
+  background: ${INK} !important;
   border: none;
   border-radius: 12px;
   font-size: 16px;
@@ -28,7 +33,7 @@ const ButtonContainer = styled(Button)`
   }
 
   :hover {
-    background: ${INK_HOVER};
+    background: ${INK_HOVER} !important;
   }
 
   @media (max-width: 600px) {
@@ -36,34 +41,44 @@ const ButtonContainer = styled(Button)`
   }
 `;
 
-const DelayedNextButton = ({ className = "", text, top, onClick, icon, delay}: NextButtonProps)  : ReactElement => {
-
+const DelayedNextButton = ({
+  className = "",
+  text,
+  top,
+  onClick,
+  icon,
+  delay,
+}: NextButtonProps): ReactElement => {
   let [shown, setShown] = useState(false);
 
-  useEffect(
-    () => {
-      let timer1 = setTimeout(()=> {
-        setShown(true);
-      }, delay);
+  useEffect(() => {
+    let timer1 = setTimeout(() => {
+      setShown(true);
+    }, delay);
 
-      // this will clear Timeout when component unmount like in willComponentUnmount
-      return () => {
-        clearTimeout(timer1)
-      }
-    }, [delay]);
+    // this will clear Timeout when component unmount like in willComponentUnmount
+    return () => {
+      clearTimeout(timer1);
+    };
+  }, [delay]);
 
-  return (
-      shown ?
-      <ButtonContainer className={className} top={top} onClick={onClick} delay={delay}>
-        {text}
-        {icon}
-      </ButtonContainer>
-          : <></>
+  return shown ? (
+    <ButtonContainer
+      className={className}
+      top={top}
+      onClick={onClick}
+      delay={delay}
+    >
+      {text}
+      {icon}
+    </ButtonContainer>
+  ) : (
+    <></>
   );
 };
 
 DelayedNextButton.defaultProps = {
-  className: ""
-}
+  className: "",
+};
 
 export default DelayedNextButton;

--- a/frontend/src/components/PurpleButton.tsx
+++ b/frontend/src/components/PurpleButton.tsx
@@ -4,16 +4,16 @@ import styled from "styled-components";
 import { INK, INK_HOVER } from "../constants/colors";
 
 interface PurpleButtonProps {
-  top?: number,
-  text?: string | '',
-  onClick?:((event: MouseEvent<HTMLInputElement>) => void),
-  check?: ReactElement,
-  icon?: ReactElement,
-  className: string
+  top?: number;
+  text?: string | "";
+  onClick?: (event: MouseEvent<HTMLInputElement>) => void;
+  check?: ReactElement;
+  icon?: ReactElement;
+  className: string;
 }
 
 const ButtonContainer = styled(Button)`
-  background: ${INK};
+  background: ${INK} !important;
   border: none;
   border-radius: 12px;
   font-size: 16px;
@@ -32,7 +32,7 @@ const ButtonContainer = styled(Button)`
   }
 
   :hover {
-    background: ${INK_HOVER};
+    background: ${INK_HOVER} !important;
   }
 
   @media (max-width: 600px) {
@@ -40,19 +40,29 @@ const ButtonContainer = styled(Button)`
   }
 `;
 
-const PurpleButton = ({ className = "", text, top, onClick, icon, check}: PurpleButtonProps)  : ReactElement => {
+const PurpleButton = ({
+  className = "",
+  text,
+  top,
+  onClick,
+  icon,
+  check,
+}: PurpleButtonProps): ReactElement => {
   return (
-    <ButtonContainer className={className} top={top} onClick={onClick}>
+    <ButtonContainer
+      className={className}
+      top={top}
+      onClick={onClick}
+    >
       {check}
       {text}
       {icon}
-
     </ButtonContainer>
   );
 };
 
 PurpleButton.defaultProps = {
-  className: ""
-}
+  className: "",
+};
 
 export default PurpleButton;


### PR DESCRIPTION
Bug: next button disappears in interventions on Firebox and Chrome.
Fix: add `!important` to styling of `PurpleButton` and `DelayedNextButton`