### PR TITLE
Fix bug where yes/no selection has blue border

### DIFF
--- a/frontend/src/components/YesNoSelection.tsx
+++ b/frontend/src/components/YesNoSelection.tsx
@@ -39,24 +39,15 @@ const YesNoButton = styled(PurpleButton)`
   ${({ highlight }: SelectionProp) => {
     if (highlight === 1) {
       return `
-    border: 5px solid ${SEA_FOAM};
-    :hover {
-      border: 5px solid ${SEA_FOAM};
-    }
+    border: 5px solid ${SEA_FOAM} !important;
   `;
     } else if (highlight === 0) {
       return `
-    border: 5px solid ${CORAL}; 
-    :hover {
-      border: 5px solid ${CORAL};
-    }
+    border: 5px solid ${CORAL} !important; 
   `;
     } else {
       return `
-    border: 0px solid ${CORAL}; 
-    :hover {
-      border: 0px solid ${CORAL};
-    }
+    border: 0px solid ${CORAL} !important; 
   `;
     }
   }};


### PR DESCRIPTION
Test steps: Go to interventions/activity 3 (on chrome). Click yes/no and confirm that when you move your mouse out it stays as the right color.