### PR TITLE
changed to no closecircle

### DIFF
--- a/frontend/src/components/YesNoSelection.tsx
+++ b/frontend/src/components/YesNoSelection.tsx
@@ -87,10 +87,10 @@ const YesNoSelection: FunctionComponent<YesNoSelectionProps> = ({
           top={20}
           check={
             selected === 0 ? (
-              !correctAnswer ? (
-                <CheckCircleFilled style={{ color: SEA_FOAM }} />
-              ) : (
+              correctAnswer ? (
                 <CloseCircleFilled style={{ color: CORAL }} />
+              ) : (
+                <CheckCircleFilled style={{ color: SEA_FOAM }} />
               )
             ) : (
               <EmptyDiv />

--- a/frontend/src/components/YesNoSelection.tsx
+++ b/frontend/src/components/YesNoSelection.tsx
@@ -1,5 +1,6 @@
 import {
   CheckCircleFilled,
+  CloseCircleFilled,
   DislikeFilled,
   LikeFilled,
 } from "@ant-design/icons";
@@ -71,7 +72,7 @@ const YesNoSelection: FunctionComponent<YesNoSelectionProps> = ({
               correctAnswer ? (
                 <CheckCircleFilled style={{ color: SEA_FOAM }} />
               ) : (
-                <CheckCircleFilled style={{ color: CORAL }} />
+                <CloseCircleFilled style={{ color: CORAL }} />
               )
             ) : (
               <EmptyDiv />
@@ -86,10 +87,10 @@ const YesNoSelection: FunctionComponent<YesNoSelectionProps> = ({
           top={20}
           check={
             selected === 0 ? (
-              correctAnswer ? (
-                <CheckCircleFilled style={{ color: CORAL }} />
-              ) : (
+              !correctAnswer ? (
                 <CheckCircleFilled style={{ color: SEA_FOAM }} />
+              ) : (
+                <CloseCircleFilled style={{ color: CORAL }} />
               )
             ) : (
               <EmptyDiv />


### PR DESCRIPTION
Switched up the logic since we want checkcircle for no if the correctAnswer is false, meaning the pic doesn't represent the word
<img width="300" alt="Screen Shot 2021-03-01 at 9 29 19 PM" src="https://user-images.githubusercontent.com/45154128/109587644-6f5e3600-7ad5-11eb-9c0e-d49a6d81abeb.png">
<img width="353" alt="Screen Shot 2021-03-01 at 9 29 16 PM" src="https://user-images.githubusercontent.com/45154128/109587648-6ff6cc80-7ad5-11eb-84b8-b432161460ff.png">
<img width="333" alt="Screen Shot 2021-03-01 at 9 27 39 PM" src="https://user-images.githubusercontent.com/45154128/109587649-6ff6cc80-7ad5-11eb-8a99-214914a70357.png">
<img width="360" alt="Screen Shot 2021-03-01 at 9 27 34 PM" src="https://user-images.githubusercontent.com/45154128/109587650-6ff6cc80-7ad5-11eb-861e-b91e8779c53c.png">
