### PR TITLE
Update intervention updating to not fetch every time

### DIFF
--- a/frontend/src/firebase/firebaseInteractor.ts
+++ b/frontend/src/firebase/firebaseInteractor.ts
@@ -171,7 +171,7 @@ export default class FirebaseInteractor {
    * update intervention idx number
    */
   async updateIntervention(
-    setId: string,
+    interventions: Interventions,
     wordIdx: number,
     activityIdx: number,
     durationInSeconds: number,
@@ -180,9 +180,11 @@ export default class FirebaseInteractor {
     activity3Part2Correct?: boolean,
     activity3Part3Correct?: boolean
   ) {
-    let intervention = await this.db.collection("interventions").doc(setId);
+    let intervention = await this.db
+      .collection("interventions")
+      .doc(interventions.setId);
 
-    let wordList: string[] = (await intervention.get())?.data()?.wordList || [];
+    let wordList: string[] = interventions.wordList.map((word) => word.word.id);
     if (activity2Correct !== undefined) {
       await intervention.collection("responses").doc(wordList[wordIdx]).set({
         activity2Correct,

--- a/frontend/src/firebase/firebaseInteractor.ts
+++ b/frontend/src/firebase/firebaseInteractor.ts
@@ -180,7 +180,7 @@ export default class FirebaseInteractor {
     activity3Part2Correct?: boolean,
     activity3Part3Correct?: boolean
   ) {
-    let intervention = await this.db
+    let intervention = this.db
       .collection("interventions")
       .doc(interventions.setId);
 

--- a/frontend/src/pages/Interventions/Activities.tsx
+++ b/frontend/src/pages/Interventions/Activities.tsx
@@ -28,7 +28,7 @@ interface ActivityProps {
   error?: Error;
   getInterventions: (id: string) => void;
   updateIntervention: ({
-    setId,
+    intervention,
     wordIdx,
     activityIdx,
     durationInSeconds,
@@ -37,7 +37,7 @@ interface ActivityProps {
     answer3Part2Correct,
     answer3Part3Correct,
   }: {
-    setId: string;
+    intervention: Interventions;
     wordIdx: number;
     activityIdx: number;
     durationInSeconds: number;
@@ -130,7 +130,7 @@ const Activities: FunctionComponent<ActivityProps> = ({
             finishedIntervention({ setId });
           } else {
             updateIntervention({
-              setId,
+              intervention: interventions,
               wordIdx: nextWordIdx,
               activityIdx: nextActivityIdx,
               durationInSeconds,

--- a/frontend/src/pages/Interventions/data/actions.ts
+++ b/frontend/src/pages/Interventions/data/actions.ts
@@ -39,7 +39,7 @@ export const getCurrentIntervention = {
 };
 
 interface UpdateInterventionAction {
-  setId: string;
+  intervention: Interventions;
   wordIdx: number;
   activityIdx: number;
   durationInSeconds: number;
@@ -55,7 +55,7 @@ interface UpdateInterventionSuccess {
 
 export const updateIntervention = {
   request: ({
-    setId,
+    intervention,
     wordIdx,
     activityIdx,
     durationInSeconds,
@@ -67,7 +67,7 @@ export const updateIntervention = {
     return {
       type: ActionTypes.UPDATE_INTERVENTION_REQUEST,
       payload: {
-        setId,
+        intervention,
         wordIdx,
         activityIdx,
         durationInSeconds,

--- a/frontend/src/pages/Interventions/data/saga.ts
+++ b/frontend/src/pages/Interventions/data/saga.ts
@@ -51,7 +51,7 @@ function* watchGetInterventions(action: Action) {
 function* watchUpdateIntervention(action: Action) {
   try {
     let {
-      setId,
+      intervention,
       wordIdx,
       activityIdx,
       durationInSeconds,
@@ -63,7 +63,7 @@ function* watchUpdateIntervention(action: Action) {
     let interventions;
     const updateAndGetNewInterventions = async () => {
       await firebaseInteractor.updateIntervention(
-        setId,
+        intervention,
         wordIdx,
         activityIdx,
         durationInSeconds,
@@ -72,7 +72,9 @@ function* watchUpdateIntervention(action: Action) {
         answer3Part2Correct,
         answer3Part3Correct
       );
-      interventions = await firebaseInteractor.getIntervention(setId);
+      intervention.wordIdx = wordIdx;
+      intervention.activityIdx = activityIdx;
+      interventions = intervention;
     };
     yield call(updateAndGetNewInterventions);
     yield put(updateIntervention.success({ interventions }));


### PR DESCRIPTION
I got annoyed at interventions taking forever to update, so I fixed it. Basically, we refetched the intervention every time, instead of mutating our local copy. This updates the code to mutate the local copy since we are putting the values in firebase a second before mutating.