### PR TITLE
Have a log out button on the error screen

### DIFF
--- a/frontend/src/pages/Errors/ErrorScreen.tsx
+++ b/frontend/src/pages/Errors/ErrorScreen.tsx
@@ -1,9 +1,13 @@
 import React from "react";
+import { connect } from "react-redux";
 import { useHistory } from "react-router";
 import styled from "styled-components";
 import CloudGroup from "../../components/CloudGroup";
 import Layout from "../../components/Layout";
 import PurpleButton from "../../components/PurpleButton";
+import { INK } from "../../constants/colors";
+import { SignOut } from "../Dashboard/data/actions";
+import { getIsSignedOut } from "../Dashboard/data/reducer";
 
 const TitleText = styled.p`
   font-family: "Rubik";
@@ -14,6 +18,23 @@ const TitleText = styled.p`
   padding: 20px;
 `;
 
+const SignOutButton = styled.button`
+  background-color: #fff0;
+  border-width: 0px;
+  color: ${INK};
+  font-weight: bold;
+  text-align: left;
+  z-index: 100;
+
+  :hover {
+    cursor: pointer;
+  }
+
+  :active {
+    opacity: 0.8;
+  }
+`;
+
 const WrappingDiv = styled.div`
   display: flex;
   align-items: center;
@@ -21,8 +42,27 @@ const WrappingDiv = styled.div`
   flex-direction: column;
 `;
 
-export default function ErrorScreen() {
+interface ErrorScreenProps {
+  logOut: () => void;
+  signedOut: boolean;
+}
+
+const connector = connect(
+  (state) => ({
+    signedOut: getIsSignedOut(state),
+  }),
+  {
+    logOut: SignOut.request,
+  }
+);
+
+function ErrorScreen({ logOut, signedOut }: ErrorScreenProps) {
   let history = useHistory();
+
+  if (signedOut) {
+    history.push("/login");
+  }
+
   return (
     <Layout>
       <>
@@ -33,8 +73,11 @@ export default function ErrorScreen() {
             text="return to dashboard"
             onClick={() => history.push("/dashboard")}
           />
+          <SignOutButton onClick={logOut}>log out</SignOutButton>
         </WrappingDiv>
       </>
     </Layout>
   );
 }
+
+export default connector(ErrorScreen);


### PR DESCRIPTION
I noticed you could get yourself into a situation where the dashboard is broken (like if you have an old account without data) and the error screen only sends you to the dashboard (the first step of recursion is trust the recursive call?). This adds a log out button.