### PR TITLE
Show cloud group on mid-size screens

### DIFF
--- a/frontend/src/components/CloudGroup.tsx
+++ b/frontend/src/components/CloudGroup.tsx
@@ -26,8 +26,9 @@ const CloudImageRight = styled(CloudImage)`
   right: 0;
   width: 15%;
   @media (max-width: 900px) {
-    top: 3em;
+    top: 4em;
     width: 20%;
+    z-index: 50;
   }
   @media (min-width: 901px) {
     bottom: 30%;


### PR DESCRIPTION
Now that the top is opaque, the cloud is cut off. This fixes it on small screens
<img width="686" alt="image" src="https://user-images.githubusercontent.com/20172570/112081739-8d5e0a00-8b5a-11eb-978f-afe617b85ad2.png">
