### PR TITLE
Make week container responsive

### DIFF
--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -390,35 +390,30 @@ const DayLabel = styled.p<DayLabelType>`
 `;
 
 const Star = styled.img`
-  height: 51px;
-  width: 52px;
+  height: 3.5vw;
+  width: 3.5vw;
 
   @media (max-width: 900px) {
-    height: 35px;
-    width: 36px;
+    height: 8vw;
+    width: 8vw;
   }
 `;
 
 const DotContainer = styled.div`
-  height: 51px;
-  width: 52px;
+  height: 3vw;
+  width: 3vw;
   display: flex;
   justify-content: center;
   align-items: center;
 
   @media (max-width: 900px) {
-    height: 35px;
-    width: 36px;
+    height: 6vw;
+    width: 6vw;
   }
 `;
 const Dot = styled.img`
-  height: 12px;
-  width: 12px;
-
-  @media (max-width: 900px) {
-    height: 10px;
-    width: 10px;
-  }
+  height: 20%;
+  width: 20%;
 `;
 
 const WeekContainer = styled.div`


### PR DESCRIPTION
Small tweak I noticed that would make the dashboard more responsive

900px screen width BEFORE:

<img width="911" alt="Screen Shot 2021-03-27 at 3 00 45 PM" src="https://user-images.githubusercontent.com/17476012/112731414-724e1a00-8f0d-11eb-85ea-f39ad2a61e76.png">


AFTER:

<img width="911" alt="Screen Shot 2021-03-27 at 3 00 52 PM" src="https://user-images.githubusercontent.com/17476012/112731419-7c701880-8f0d-11eb-8009-6f4ae4243a5f.png">

