### PR TITLE
Fixed up issue regarding to assessment session id and total sessions

### DIFF
--- a/frontend/src/firebase/firebaseInteractor.ts
+++ b/frontend/src/firebase/firebaseInteractor.ts
@@ -318,7 +318,7 @@ export default class FirebaseInteractor {
       currentIndex,
       words: actualWords,
       firebaseId: assessment.id,
-      sessionId: assessment.session === undefined ? -1 : 0,
+      sessionId: assessment.session === undefined ? -1 : assessment.session,
     };
   }
 
@@ -360,7 +360,7 @@ export default class FirebaseInteractor {
       .get();
     if (documents.docs.length > 0) {
       await this.updateCurrentUser({
-        sessionId: sessionId < 9 ? ((sessionId + 1) as SessionId) : sessionId,
+        sessionId: sessionId < 8 ? ((sessionId + 1) as SessionId) : sessionId,
         onAssessment: false,
         currentInterventionOrAssessment: documents.docs.filter(
           (doc) => doc.data().session === sessionId + 1

--- a/frontend/src/models/types.ts
+++ b/frontend/src/models/types.ts
@@ -214,4 +214,4 @@ export interface AssessmentResult {
   correct: boolean;
 }
 
-export type SessionId = -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+export type SessionId = -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;

--- a/frontend/src/pages/Dashboard/StudentDashboard.tsx
+++ b/frontend/src/pages/Dashboard/StudentDashboard.tsx
@@ -306,7 +306,7 @@ const getTitleOfButton = (user: User): string => {
   switch (user.sessionId) {
     case -1:
       return "Begin pre-assessment";
-    case 9:
+    case 8:
       return "Congratulations on finishing the study";
     default:
       return (
@@ -462,7 +462,7 @@ const StudentDashboard: FunctionComponent<StudentDashboardParams> = ({
                     : "/interventions"
                 )
               }
-              disabled={student.sessionId === 9}
+              disabled={student.sessionId === 8}
             />
           </>
         ) : (


### PR DESCRIPTION
Previously we would set the session id to 0 for all assessments. What this means is that we would never go past session 2. As well, we had one too many sessionId possibilities, now there is the correct amount.
-1 -> Pre-assessment
0-7 -> The 8 intervention/assessment sessions
8 -> Finished 