### PR TITLE
Change the loading of the stats to speed up

### DIFF
--- a/frontend/src/firebase/firebaseInteractor.ts
+++ b/frontend/src/firebase/firebaseInteractor.ts
@@ -513,9 +513,8 @@ export default class FirebaseInteractor {
       let interventionResults = (
         await interventionForSession.ref.collection("responses").get()
       ).docs;
-      let interventionWords = interventionForSession.data()
-        .wordList as string[];
-      for (let word of interventionWords) {
+      let interventionWords = interventionForSession.data().wordList;
+      for (let word of interventionWords as string[]) {
         let actualWord = await this.getWord(word);
         let currentWordAssessmentStats = assessmentResultObjects?.docs.filter(
           (doc) => doc.id === word


### PR DESCRIPTION
With a timer, the old way would take 2 seconds, and the new way takes 1 second. This is important for the downloading data step, since it speeds up the download tremendously (up to 50%). The holdup was that fetching an intervention is pretty slow, I might look into why that is later.