### PR TITLE
Database Mods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ dist
 /.idea/
 
 scripts/firebase-*.json
+scripts/words

--- a/frontend/src/components/DelayedNextButton.tsx
+++ b/frontend/src/components/DelayedNextButton.tsx
@@ -1,10 +1,5 @@
 import { Button } from "antd";
-import React, {
-  MouseEvent,
-  ReactElement,
-  useState,
-  useEffect,
-} from "react";
+import React, { MouseEvent, ReactElement } from "react";
 import styled from "styled-components";
 import { INK, INK_HOVER } from "../constants/colors";
 
@@ -52,19 +47,6 @@ const DelayedNextButton = ({
   delay,
   canBeShown,
 }: DelayedNextButton): ReactElement => {
-  let [shown, setShown] = useState(false);
-
-  useEffect(() => {
-    let timer1 = setTimeout(() => {
-      setShown(true);
-    }, delay);
-
-    // this will clear Timeout when component unmount like in willComponentUnmount
-    return () => {
-      clearTimeout(timer1);
-    };
-  }, [delay]);
-
   return canBeShown ? (
     <ButtonContainer
       className={className}

--- a/frontend/src/components/TriggeredPrompt.tsx
+++ b/frontend/src/components/TriggeredPrompt.tsx
@@ -70,7 +70,7 @@ const TriggeredPrompt: FunctionComponent<TriggeredPromptProps> = ({
       audio2.play();
       setLastPlayed("audio2");
     }
-  }, [onClickHandler, isAssessment, audio2]);
+  }, [onClickHandler, isAssessment, triggerSecondPrompt, audio2]);
 
   audio1.onpause = onPauseCallback;
   audio2.onended = secondPromptFinishedHandler || (() => {});

--- a/frontend/src/constants/images.ts
+++ b/frontend/src/constants/images.ts
@@ -2,9 +2,13 @@
 export const ASSESSMENTS_LANDING =
   "https://firebasestorage.googleapis.com/v0/b/vocab-buddy-53eca.appspot.com/o/assessments-landing.png?alt=media&token=168586ea-bb4e-499c-a711-5f3fe7a375b9";
 
+// Assessments
+export const INTERVENTIONS_LANDING =
+  "https://firebasestorage.googleapis.com/v0/b/vocab-buddy-53eca.appspot.com/o/interventions-landing.png?alt=media&token=168586ea-bb4e-499c-a711-5f3fe7a375b9";
+
 // Reward balloon
 export const BALLOON =
   "https://firebasestorage.googleapis.com/v0/b/vocab-buddy-53eca.appspot.com/o/balloon.svg?alt=media&token=003857c8-e0d6-48a1-bf0d-63124db1b935";
 
 export const ERROR_IMAGE =
-  "https://firebasestorage.googleapis.com/v0/b/vocab-buddy-53eca.appspot.com/o/icons%2Ferrorscreen_illustration.svg?alt=media&token=601b55ee-6869-4d1b-b808-032d5902a8e6";
+  "https://firebasestorage.googleapis.com/v0/b/vocab-buddy-53eca.appspot.com/o/errorscreen_illustration.png?alt=media&token=601b55ee-6869-4d1b-b808-032d5902a8e6";

--- a/frontend/src/firebase/firebaseInteractor.ts
+++ b/frontend/src/firebase/firebaseInteractor.ts
@@ -142,7 +142,7 @@ export default class FirebaseInteractor {
     let idToUse = id || this.auth.currentUser?.uid;
     let user = await this.db.collection("users").doc(idToUse).get();
     let userData = user.data();
-    if (userData != undefined) {
+    if (userData !== undefined) {
       return this.getUserFromData(idToUse || "", userData);
     } else {
       if (id === undefined) {

--- a/frontend/src/firebase/firebaseInteractor.ts
+++ b/frontend/src/firebase/firebaseInteractor.ts
@@ -8,17 +8,18 @@ import {
   AccountType,
   Assessment,
   AssessmentResult,
-  Context,
-  Definition,
-  Example,
+  FirebaseAssessmentResults,
+  FirebaseInterventionResult,
+  FirebaseInterventionResults,
+  FirebaseWordIntervention,
   Interventions,
   InterventionWord,
-  Review,
   SessionId,
   SessionStats,
   User,
   UserSettings,
   Word,
+  WordMapping,
   WordResult,
 } from "../models/types";
 
@@ -178,6 +179,7 @@ export default class FirebaseInteractor {
       words: wordIds,
       userId: this.auth.currentUser?.uid,
       session: -1,
+      results: {},
     };
     let newAssessment = this.db.collection("assessments").doc();
     await newAssessment.set(newAssessmentFields);
@@ -205,33 +207,38 @@ export default class FirebaseInteractor {
       .collection("interventions")
       .doc(interventions.setId);
 
+    let newResult: FirebaseInterventionResult = {};
+
     let wordList: string[] = interventions.wordList.map((word) => word.word.id);
     if (activity2Correct !== undefined) {
-      await intervention.collection("responses").doc(wordList[wordIdx]).set({
+      newResult = {
         activity2ImageSelected,
         activity2Correct,
-      });
+      };
     }
 
     if (activity3Correct !== undefined) {
-      await intervention.collection("responses").doc(wordList[wordIdx]).update({
+      newResult = {
+        ...newResult,
         activity3Image,
         activity3Correct,
-      });
+      };
     }
 
     if (activity3Part2Correct !== undefined) {
-      await intervention.collection("responses").doc(wordList[wordIdx]).update({
+      newResult = {
+        ...newResult,
         activity3Part2Image,
         activity3Part2Correct,
-      });
+      };
     }
 
     if (activity3Part3Correct !== undefined) {
-      await intervention.collection("responses").doc(wordList[wordIdx]).update({
+      newResult = {
+        ...newResult,
         activity3Part3Image,
         activity3Part3Correct,
-      });
+      };
     }
 
     const increment = firebase.firestore.FieldValue.increment(
@@ -242,9 +249,10 @@ export default class FirebaseInteractor {
       wordIdx,
       activityIdx,
       durationsInSeconds: increment,
+      results: { [wordList[wordIdx]]: newResult },
     };
 
-    intervention.update(object);
+    intervention.set(object, { merge: true });
     this.updateDaysActive();
   }
 
@@ -288,6 +296,7 @@ export default class FirebaseInteractor {
       words: wordList,
       userId: this.auth.currentUser?.uid,
       session: this.currentUser?.sessionId,
+      results: {},
     };
     await newAssessment.set(initialAssessmentFields);
     await this.updateCurrentUser({
@@ -347,28 +356,27 @@ export default class FirebaseInteractor {
     currentIdx: number,
     durationsInSeconds: number
   ) {
-    await Promise.all(
-      responses.map(async (response) => {
-        return await this.db
-          .collection("assessments")
-          .doc(id)
-          .collection("results")
-          .doc(response.word)
-          .set({
-            correct: response.correct,
-            imageSelected: response.imageSelected,
-          });
-      })
-    );
-
     const increment = firebase.firestore.FieldValue.increment(
       durationsInSeconds
     );
 
-    await this.db.collection("assessments").doc(id).update({
-      currentIndex: currentIdx,
-      durationsInSeconds: increment,
-    });
+    await this.db
+      .collection("assessments")
+      .doc(id)
+      .update({
+        ...Object.fromEntries(
+          responses.map((response) => [
+            `results.${response.word}`,
+            {
+              correct: response.correct,
+              imageSelected: response.imageSelected,
+            },
+          ])
+        ),
+        currentIndex: currentIdx,
+        durationsInSeconds: increment,
+      });
+
     this.updateDaysActive();
   }
 
@@ -391,23 +399,18 @@ export default class FirebaseInteractor {
       });
       return;
     }
-    let responses = await this.db
-      .collection("assessments")
-      .doc(id)
-      .collection("results")
-      .where("correct", "==", false)
-      .get();
-    let incorrectWords = responses.docs.map((response) => ({
-      word: response.id,
-      correct: false,
-    }));
+    let results = (await this.db.collection("assessments").doc(id).get()).data()
+      ?.results as FirebaseAssessmentResults;
+    let incorrectWords = Object.entries(results)
+      .filter(([_id, result]) => !result.correct)
+      .map(([id, _result]) => id);
     shuffle(incorrectWords);
     for (let i = 0; i < 8; i++) {
       // Add 3 words per intervention (wrapping around for now)
       let wordList = [
-        incorrectWords[(i * 3) % incorrectWords.length].word,
-        incorrectWords[(i * 3 + 1) % incorrectWords.length].word,
-        incorrectWords[(i * 3 + 2) % incorrectWords.length].word,
+        incorrectWords[(i * 3) % incorrectWords.length],
+        incorrectWords[(i * 3 + 1) % incorrectWords.length],
+        incorrectWords[(i * 3 + 2) % incorrectWords.length],
       ];
       let newIntervention = await this.db.collection("interventions").add({
         durationsInSeconds: 0,
@@ -418,6 +421,7 @@ export default class FirebaseInteractor {
         userId: this.auth.currentUser?.uid,
         // Decide which session the intervention is in
         session: i,
+        results: {},
       });
       if (i === 0) {
         await this.updateCurrentUser({
@@ -457,23 +461,16 @@ export default class FirebaseInteractor {
     for (let word of intervention.wordList as string[]) {
       // Get the word
       let actualWord = await this.getWord(word);
-      let wordRef = this.db
-        .collection("words")
-        .doc(word)
-        .collection("intervention-set");
-      // Get each activity from firebase
-      let activity1 = (
-        await wordRef.doc("activity1").get()
-      ).data() as Definition;
-      let activity2 = (await wordRef.doc("activity2").get()).data() as Example;
-      let activity3 = (await wordRef.doc("activity3").get()).data() as Context;
-      let activity4 = (await wordRef.doc("activity4").get()).data() as Review;
-      let activity3Part2 = (
-        await wordRef.doc("activity3-part2").get()
-      ).data() as Context;
-      let activity3Part3 = (
-        await wordRef.doc("activity3-part3").get()
-      ).data() as Context;
+      let {
+        activity1,
+        activity2,
+        activity3,
+        activity3Part2,
+        activity3Part3,
+        activity4,
+      } = (await this.db.collection("words").doc(word).get()).data()
+        ?.interventionSet as FirebaseWordIntervention;
+
       interventionWords.push({
         word: actualWord,
         activities: {
@@ -499,7 +496,8 @@ export default class FirebaseInteractor {
   // get stats for the given user's given session
   async getStatsForSession(
     userId: string,
-    sessionId: number
+    sessionId: number,
+    idToWord: WordMapping = new Map()
   ): Promise<SessionStats> {
     let interventionForSession = (
       await this.db
@@ -527,53 +525,46 @@ export default class FirebaseInteractor {
     let incorrect = 0;
     let wordResults: WordResult[] = [];
     let assessmentResultObjects:
-      | firebase.firestore.QuerySnapshot<firebase.firestore.DocumentData>
+      | FirebaseAssessmentResults
       | undefined = undefined;
 
     if (assessmentForSession !== undefined) {
       assessmentDuration =
         Math.round(assessmentForSession.data().durationsInSeconds * 100) / 100;
-      let assessmentResults = await assessmentForSession.ref
-        .collection("results")
-        .get();
+      let assessmentResults = assessmentForSession.data()
+        .results as FirebaseAssessmentResults;
       assessmentResultObjects = assessmentResults;
-      correct = assessmentResults.docs.filter((doc) => doc.data().correct)
+      correct = Object.values(assessmentResults).filter((doc) => doc.correct)
         .length;
-      incorrect = assessmentResults.docs.filter((doc) => !doc.data().correct)
+      incorrect = Object.values(assessmentResults).filter((doc) => !doc.correct)
         .length;
     }
 
     if (interventionForSession) {
-      let interventionResults = (
-        await interventionForSession.ref.collection("responses").get()
-      ).docs;
+      let interventionResults = (await interventionForSession.data()
+        .results) as FirebaseInterventionResults;
       let interventionWords = interventionForSession.data().wordList;
       for (let word of interventionWords as string[]) {
-        let actualWord = await this.getWord(word);
-        let currentWordAssessmentStats = assessmentResultObjects?.docs.filter(
-          (doc) => doc.id === actualWord.id
-        )[0];
-        let currentWordInterventionStats = interventionResults.filter(
-          (doc) => doc.id === actualWord.id
-        )[0];
+        let actualWord = idToWord.get(word) || (await this.getWord(word));
+        let currentWordAssessmentStats = assessmentResultObjects?.[word];
+        let currentWordInterventionStats = interventionResults[word];
         let wordStats: WordResult = {
           word: actualWord.value,
-          assessmentCorrect: currentWordAssessmentStats?.data().correct,
-          assessmentImageSelected: currentWordAssessmentStats?.data()
-            .imageSelected,
-          ...currentWordInterventionStats?.data(),
+          assessmentCorrect: currentWordAssessmentStats?.correct,
+          assessmentImageSelected: currentWordAssessmentStats?.imageSelected,
+          ...currentWordInterventionStats,
         };
         wordResults.push(wordStats);
       }
     }
 
     if (sessionId === -1) {
-      for (let result of assessmentResultObjects?.docs ?? []) {
-        let word = await this.getWord(result.id);
+      for (let [id, result] of Object.entries(assessmentResultObjects ?? {})) {
+        let word = idToWord.get(id) || (await this.getWord(id));
         wordResults.push({
           word: word.value,
-          assessmentCorrect: result.data().correct,
-          assessmentImageSelected: result.data().imageSelected,
+          assessmentCorrect: result.correct,
+          assessmentImageSelected: result.imageSelected,
         });
       }
     }
@@ -600,8 +591,10 @@ export default class FirebaseInteractor {
       if (assessment.data().sessionId === -1) {
         continue;
       }
-      let results = await assessment.ref.collection("results").get();
-      totalWords += results.docs.filter((doc) => doc.data().correct).length;
+      let results = (await assessment.data()
+        .results) as FirebaseAssessmentResults;
+      totalWords += Object.values(results).filter((result) => result.correct)
+        .length;
     }
     return totalWords;
   }
@@ -612,23 +605,35 @@ export default class FirebaseInteractor {
     if (folder === null) {
       throw new Error("Error downloading data. Please try again.");
     }
-    const students = await this.getAllStudents();
+    const [idToWord, students] = await Promise.all([
+      this.getAllWords(),
+      this.getAllStudents(),
+    ]);
     const promises = students.map((student) =>
-      this.getDataForOneUser(student.id, student.name, folder).catch((error) =>
-        console.log(error)
-      )
+      this.getDataForOneUser(
+        student.id,
+        student.name,
+        folder,
+        idToWord
+      ).catch((error) => console.log(error))
     );
     await Promise.all(promises);
     let fileBlob = await zip.generateAsync({ type: "blob" });
     window.open(URL.createObjectURL(fileBlob));
   }
 
-  async getDataForOneUser(userId: string, name: string, zip: JSZip) {
-    let sessionStats: SessionStats[] = [];
+  async getDataForOneUser(
+    userId: string,
+    name: string,
+    zip: JSZip,
+    idToWord: WordMapping = new Map()
+  ) {
+    let sessionPromises: Promise<SessionStats>[] = [];
     for (let idx = -1; idx < 8; idx++) {
-      sessionStats.push(await this.getStatsForSession(userId, idx));
+      sessionPromises.push(this.getStatsForSession(userId, idx, idToWord));
     }
     const folder = zip.folder(name);
+    const sessionStats = await Promise.all(sessionPromises);
     sessionStats.forEach((stats, index) => {
       folder?.file(
         index === 0 ? "pre-assessment.csv" : `session${index}.csv`,
@@ -657,7 +662,8 @@ export default class FirebaseInteractor {
 
   async createDataZip(userId: string, name: string) {
     const zip = new JSZip();
-    await this.getDataForOneUser(userId, name, zip);
+    const idToWord = await this.getAllWords();
+    await this.getDataForOneUser(userId, name, zip, idToWord);
     let fileBlob = await zip.generateAsync({ type: "blob" });
     window.open(URL.createObjectURL(fileBlob));
   }
@@ -805,5 +811,19 @@ export default class FirebaseInteractor {
       let studentData = student.data();
       return this.getUserFromData(student.id, studentData);
     });
+  }
+
+  async getAllWords(): Promise<WordMapping> {
+    const idToWord: WordMapping = new Map();
+    let words = (await this.db.collection("words").get()).docs;
+
+    for (let word of words) {
+      idToWord.set(word.id, {
+        ...word.data(),
+        createdAt: word.data().dateCreated.toDate(),
+      } as Word);
+    }
+
+    return idToWord;
   }
 }

--- a/frontend/src/models/types.ts
+++ b/frontend/src/models/types.ts
@@ -224,6 +224,41 @@ export interface SessionStats {
   wordResults: WordResult[];
 }
 
+export interface WordMapping extends Map<string, Word> {}
+
+export interface FirebaseAssessmentResult {
+  correct: boolean;
+  imageSelected: string;
+}
+
+export interface FirebaseAssessmentResults {
+  [id: string]: FirebaseAssessmentResult;
+}
+
+export interface FirebaseInterventionResult {
+  activity2Correct?: boolean;
+  activity2ImageSelected?: string;
+  activity3Correct?: boolean;
+  activity3Image?: string;
+  activity3Part2Correct?: boolean;
+  activity3Part2Image?: string;
+  activity3Part3Correct?: boolean;
+  activity3Part3Image?: string;
+}
+
+export interface FirebaseInterventionResults {
+  [id: string]: FirebaseInterventionResult;
+}
+
+export interface FirebaseWordIntervention {
+  activity1: Definition;
+  activity2: Example;
+  activity3: Context;
+  activity3Part2: Context;
+  activity3Part3: Context;
+  activity4: Review;
+}
+
 export interface WordResult {
   word: string;
   assessmentCorrect?: boolean;

--- a/frontend/src/pages/Dashboard/SessionDashboard.tsx
+++ b/frontend/src/pages/Dashboard/SessionDashboard.tsx
@@ -232,7 +232,11 @@ const WordResultDiv = ({
 }: {
   word: WordResult;
   isPreassessment: boolean;
-  setModalImage: (val?: { src?: string; selected?: true }) => void;
+  setModalImage: (val?: {
+    word?: string;
+    src?: string;
+    selected?: true;
+  }) => void;
 }) => {
   return (
     <WordResultWrapper>
@@ -248,6 +252,7 @@ const WordResultDiv = ({
                 setModalImage({
                   src: word.assessmentImageSelected,
                   selected: true,
+                  word: word.word,
                 })
               }
             />
@@ -331,6 +336,7 @@ const SessionDashboard: FunctionComponent<SessionDashboardParams> = ({
   const [modalImage, setModalImage] = useState<{
     src?: string;
     selected?: boolean;
+    word?: string;
   }>();
   return (
     <SessionContainer>
@@ -363,6 +369,7 @@ const SessionDashboard: FunctionComponent<SessionDashboardParams> = ({
           footer={null}
         >
           <img
+            alt={modalImage?.word}
             style={{ borderRadius: "20px", width: "100%" }}
             src={modalImage?.src}
           />

--- a/frontend/src/pages/Dashboard/Settings.tsx
+++ b/frontend/src/pages/Dashboard/Settings.tsx
@@ -162,7 +162,7 @@ const Settings: FunctionComponent<SettingsProps> = ({
     if (networkErrorShown) {
       setShowSuccessToast(true);
     }
-  }, [user]);
+  }, [user, networkErrorShown]);
 
   return (
     <LoginHoldingDiv>

--- a/frontend/src/pages/Dashboard/StudentDashboard.tsx
+++ b/frontend/src/pages/Dashboard/StudentDashboard.tsx
@@ -307,7 +307,7 @@ const BackToDashboard = styled.p`
 `;
 
 const getTitleOfButton = (user: User): string => {
-  if (user.currentInterventionOrAssessment) {
+  if (user.currentInterventionOrAssessment === "") {
     return "Congratulations on finishing the study";
   }
   switch (user.sessionId) {

--- a/frontend/src/pages/Dashboard/StudentDashboard.tsx
+++ b/frontend/src/pages/Dashboard/StudentDashboard.tsx
@@ -307,6 +307,9 @@ const BackToDashboard = styled.p`
 `;
 
 const getTitleOfButton = (user: User): string => {
+  if (user.currentInterventionOrAssessment) {
+    return "Congratulations on finishing the study";
+  }
   switch (user.sessionId) {
     case -1:
       return "Begin pre-assessment";
@@ -491,7 +494,10 @@ const StudentDashboard: FunctionComponent<StudentDashboardParams> = ({
                     : "/interventions"
                 )
               }
-              disabled={student.sessionId === 8}
+              disabled={
+                student.sessionId === 8 ||
+                student.currentInterventionOrAssessment === ""
+              }
             />
           </>
         ) : (

--- a/frontend/src/pages/Interventions/FirstActivity.tsx
+++ b/frontend/src/pages/Interventions/FirstActivity.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement, useState } from "react";
 import styled from "styled-components";
 import Blocker from "../../components/Blocker";
 import Layout from "../../components/Layout";

--- a/frontend/src/pages/Interventions/FourthActivity.tsx
+++ b/frontend/src/pages/Interventions/FourthActivity.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement, useState } from "react";
 import styled from "styled-components";
 import Layout from "../../components/Layout";
 import DelayedNextButton from "../../components/DelayedNextButton";

--- a/frontend/src/pages/Interventions/Interventions.tsx
+++ b/frontend/src/pages/Interventions/Interventions.tsx
@@ -4,7 +4,7 @@ import React, {
   useState,
 } from "react";
 import LandingPage from "../../components/LandingPage";
-import { ASSESSMENTS_LANDING } from "../../constants/images";
+import { INTERVENTIONS_LANDING } from "../../constants/images";
 import { useHistory } from "react-router-dom";
 import { connect } from "react-redux";
 import { getCurrentIntervention } from "./data/actions";
@@ -44,7 +44,7 @@ const Interventions: FunctionComponent<InterventionProps> = ({
           getInterventionRequest();
           setHasClickedButton(true);
         }}
-        image={ASSESSMENTS_LANDING}
+        image={INTERVENTIONS_LANDING}
         title="interventions"
         subtitle="start an intervention"
       />

--- a/scripts/reset-database.js
+++ b/scripts/reset-database.js
@@ -23,16 +23,20 @@ const auth = firebase.auth();
 const db = firebase.firestore();
 const storage = firebase.storage();
 
+
 const promises = []
 
 if (resetWords) {
   console.log('Deleting word-related-media from storage bucket')
   const wordDb = db.collection('words')
   const deleteWordMedias = async () => {
-    const wordIds = (await wordDb.listDocuments()).map(doc => doc.id)
-    return Promise.all(wordIds.map(id => storage.bucket().file(id).delete()))
+    const wordFiles = (await wordDb.get()).docs.flatMap((doc) => {
+      const data = doc.data();
+      return [data.assessmentPrompt, data.correctImage, ...data.incorrectImages, ...Object.values(data.interventionSet).flatMap(Object.values).filter(obj => typeof obj === 'string')].map(url => url.replace(/https\:\/\/storage\.googleapis\.com\/vocab\-buddy\-[a-z0-9]*\.appspot\.com\//, "").replace("%2F", "/"))
+    })
+    return Promise.all(wordFiles.map(file => storage.bucket().file(file).delete()))
   }
-  promises.push(deleteWordMedias.then(() => console.log('Deleted media from storage bucket')));
+  promises.push(deleteWordMedias().then(() => console.log('Deleted media from storage bucket')));
 }
 
 const databasesToClear = ['assessments', 'interventions', ...resetWords ? ['words'] : []];
@@ -44,20 +48,28 @@ promises.push(...databasesToClear.map(database => {
 
 console.log('Deleting users');
 const deleteUsers = async () => {
-  const userDb = db.collection('users');
-  const users = (await userDb.listDocuments()).map(doc => doc.id);
-  const deletedUsers = [...auth.deleteUsers(users), db.recursiveDelete(usersDb)]
-  return Promise.all(deletedUsers).then(() => console.log('Deleted all users'))
+  const usersDb = db.collection('users');
+  const users = (await usersDb.listDocuments()).map(doc => doc.id);
+  const deletedUsers = [auth.deleteUsers(users), db.recursiveDelete(usersDb)]
+  return Promise.all(deletedUsers).then(([userDeletionResults]) => {
+    console.log(`Successfully deleted ${userDeletionResults?.successCount} users from auth`)
+    if (userDeletionResults?.failureCount) {
+      console.err(`Failed to delete ${userDeletionResults.failureCount} users from auth: \n${userDeletionResults.errors.map(error => error.error.message).join('\n')}`)
+    }
+  })
 }
 
 promises.push(deleteUsers());
 
 Promise.all(promises).then(() => {
-  if (!resetWords) return;
+  if (!resetWords) {
+    process.exit();
+  }
   const { exec } = require('child_process');
   const child = exec('yarn upload');
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', (message) => {
     console.log(message.toString().trim())
   })
+  child.on('exit', () => process.exit());
 });


### PR DESCRIPTION
- Reuploaded words so correct/incorrect is now removed as per #106 (this needs to be verified on the deploy)
- Wiped database (sorry not sorry)
- Changed database structure to have overall less documents, preferring nested objects over sub-collections
  - This will hopefully reduce the number of reads for downloads 🤞 still need to test this theory.... in the meantime it's gonna break the other PRs LOL

Changes from #118 are also included in this since it's branched off of `download-improvements`, so this pr deploy hopefully should sort of replace the pr deploy for that pr

#119 is going to be put on the backburner until this is complete so we can see if it resolves those issues

One more change that I might include in this (from the researchers):
> Q: If the student ends with less than 24 incorrect answers, what should they see in their following interventions? 
> A:  For our study we are mostly interested in collecting data for kids who answer 24 items incorrectly in the pre-assessment. For students who answer fewer than 24 items incorrectly, either of these options would be OK:
Option 1: The student completes intervention/assessment activities only for the words that they answered incorrectly on the pre-assessment (i.e., if they answered 12 items incorrectly, they would complete intervention activities for those 12 words and then the program would end). 
Option 2: If Option 1 isn't possible, the program can end after the pre-assessment is completed for students who answered <24 incorrect items.

Probably going to try out option 1 where we just only populate the appropriate number of interventions and then the user ends after their final intervention, but also seems like the issue isn't super important _as long as we handle these cases in some manner without tanking the app_